### PR TITLE
build: #MO-35 [FE] 프론트 배포 자동화

### DIFF
--- a/.github/workflows/git-push.yml
+++ b/.github/workflows/git-push.yml
@@ -2,7 +2,7 @@ name: git push into another repo to deploy to vercel
 
 on:
   push:
-    branches: [main]
+    branches: [MO-35-fe-프론트-배포-자동화]
 
 jobs:
   build:

--- a/.github/workflows/git-push.yml
+++ b/.github/workflows/git-push.yml
@@ -1,0 +1,30 @@
+name: git push into another repo to deploy to vercel
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.WOOJIN_GITHUB_KEY }}
+        with:
+          source-directory: 'output'
+          destination-github-username: nijoow
+          destination-repository-name: moharu-frontend
+          user-email: ${{ secrets.WOOJIN_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/.github/workflows/git-push.yml
+++ b/.github/workflows/git-push.yml
@@ -2,7 +2,7 @@ name: git push into another repo to deploy to vercel
 
 on:
   push:
-    branches: [MO-35-fe-프론트-배포-자동화]
+    branches: [main]
 
 jobs:
   build:

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./[team-repo-name]/* ./output
+cp -R ./output ./[team-repo-name]/

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 cd ../
 mkdir output
-cp -R ./[team-repo-name]/* ./output
-cp -R ./output ./[team-repo-name]/
+cp -R ./moharu-frontend/* ./output
+cp -R ./output ./moharu-frontend/


### PR DESCRIPTION
github 팀 레포지토리는 유료인 vercel pro plan으로만 사용가능한데
저희는 일단 무료로 하기 위해서 개인 레포지토리로 folk해서 vercel hobby plan으로 배포했습니다.

그래서 팀 레포지토리의 main에 푸시되면 개인 계정에서 자동으로 build하도록 설정했습니다!