### PR TITLE
refactor: #Mo-47 [FE] api 설정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,14 @@ const nextConfig = {
 
     return config;
   },
+  async rewrites() {
+    return [
+      {
+        source: '/apis/:path*',
+        destination: `https://api.moharu.site/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/(with-navigation)/page.tsx
+++ b/src/app/(with-navigation)/page.tsx
@@ -11,19 +11,17 @@ import {
 import { Activity, Category } from '@/types/type';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { useSession } from 'next-auth/react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
 export default function Home() {
-  const { data: session } = useSession();
-  console.log(session);
   const [categoryList, setCategoryList] = useState<Category[]>([]);
   const [activities, setActivities] = useState<Activity[]>([]);
   const [date, setDate] = useState<Date>();
 
   useEffect(() => {
-    fetch(`data/categoryList.json`)
+    // EXAMPLE: 클라이언트 컴포넌트에서 api 요청
+    fetch(`/apis/activities-category`)
       .then(res => res.json())
       .then(data => {
         setCategoryList(data);
@@ -31,7 +29,7 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    fetch('data/mainActivityList.json')
+    fetch('/apis/activities')
       .then(response => response.json())
       .then(data => setActivities(data));
   }, []);
@@ -74,7 +72,7 @@ export default function Home() {
       </div>
       {/* TODO: 카테고리 바 sticky 처리 여부 */}
       <CategoryBar categoryList={categoryList} />
-      {activities.map(activity => (
+      {activities?.map(activity => (
         <MainActivityCard key={activity.id} activity={activity} />
       ))}
     </>

--- a/src/app/(with-navigation)/profile/page.tsx
+++ b/src/app/(with-navigation)/profile/page.tsx
@@ -74,7 +74,13 @@ const user: User = {
 
 export default async function Profile() {
   const session = await auth();
-  console.log(session);
+  // EXAMPLE: 서버 컴포넌트에서 api 요청 예시
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_API_URL}/user`,
+  );
+  const users = await response.json();
+
+  console.log(users);
 
   return (
     <div className="px-24px">

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,0 +1,27 @@
+import { getSession } from 'next-auth/react';
+
+interface FetchOptions extends RequestInit {
+  headers?: HeadersInit;
+}
+
+export async function fetchWithToken(url: string, options: FetchOptions = {}) {
+  const session = await getSession();
+
+  const headers = {
+    'Content-Type': 'application/json',
+    ...options.headers,
+    Authorization: `Bearer ${session?.accessToken ?? ''}`,
+  };
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.message);
+  }
+
+  return response.json();
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,8 @@
+import { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+  interface Session {
+    user: {} & DefaultSession['user'];
+    accessToken: string;
+  }
+}


### PR DESCRIPTION
- 클라이언트 컴포넌트에서는 api url을 '/apis/...') 쪽으로 요청하시면 됩니다.
  - GET: `fetch('/apis/...')`
  - POST: `fetch('/apis/...', { method:'POST' , body:...})`
- 서버 컴포넌트에서는 api url을 실제 url을 다 적으시면 됩니다.
  - `fetch('https://api.moharu.site/...')`
  - 환경변수로 url을 설정해 두어서 ```fetch(`${process.env.NEXT_PUBLIC_BACKEND_API_URL}/user`);``` 이렇게 쓰시면 됩니다.
  - .env.local 파일에 `NEXT_PUBLIC_BACKEND_API_URL=https://api.moharu.site` 추가해주세요
- 인증/인가가 필요한 api는 fetchWithToken이라는 함수불러서 fetch랑 똑같은 방식으로 쓰시면 될거에요.

메인페이지('/')가 클라이언트 컴포넌트로 만들어져있어서 api 불러오는거 임시로 적용해놨고
프로필페이지('/profile')에 서버 컴포넌트 예시도 추가해놨어요

일단은 편하신 방식으로 작업하시고 나중에 필요할때 리팩토링하면서 바꿔보는걸로 하시죠

폴더나 파일 구조는 따로 안 올리긴했는데 _component 랑 똑같이 _api 혹은 _service 같은식으로 각페이지 폴더에 만들어서 쓰고 여러 곳에서 쓰이는것만 따로 모아서 쓰면 될것같아요